### PR TITLE
Replacing Linera Amount with a built-in datastructure

### DIFF
--- a/vsl-sdk/Cargo.lock
+++ b/vsl-sdk/Cargo.lock
@@ -3,16 +3,6 @@
 version = 4
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,15 +16,6 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "allocator-api2"
@@ -72,7 +53,7 @@ checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.1",
+ "strum",
 ]
 
 [[package]]
@@ -88,7 +69,7 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more",
  "either",
  "k256",
  "once_cell",
@@ -213,7 +194,7 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more",
  "either",
  "serde",
  "sha2",
@@ -277,7 +258,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -307,7 +288,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.0.1",
+ "derive_more",
  "foldhash",
  "hashbrown 0.15.4",
  "indexmap 2.9.0",
@@ -518,7 +499,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -537,7 +518,7 @@ dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck 0.5.0",
+ "heck",
  "macro-string",
  "proc-macro2",
  "quote",
@@ -577,7 +558,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "base64 0.22.1",
- "derive_more 2.0.1",
+ "derive_more",
  "futures",
  "futures-utils-wasm",
  "parking_lot 0.12.4",
@@ -615,7 +596,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more 2.0.1",
+ "derive_more",
  "nybbles",
  "serde",
  "smallvec",
@@ -686,12 +667,6 @@ dependencies = [
  "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ark-ff"
@@ -833,86 +808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii_utils"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
-name = "async-graphql"
-version = "7.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036618f842229ba0b89652ffe425f96c7c16a49f7e3cb23b56fca7f61fd74980"
-dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
- "async-stream",
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "fast_chemail",
- "fnv",
- "futures-timer",
- "futures-util",
- "handlebars",
- "http",
- "indexmap 2.9.0",
- "mime",
- "multer",
- "num-traits",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions_next",
- "tempfile",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd45deb3dbe5da5cdb8d6a670a7736d735ba65b455328440f236dfb113727a3d"
-dependencies = [
- "Inflector",
- "async-graphql-parser",
- "darling",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "strum 0.26.3",
- "syn 2.0.103",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b7607e59424a35dadbc085b0d513aa54ec28160ee640cf79ec3b634eba66d3"
-dependencies = [
- "async-graphql-value",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ecdaff7c9cffa3614a9f9999bf9ee4c3078fe3ce4d6a6e161736b56febf2de"
-dependencies = [
- "bytes",
- "indexmap 2.9.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,16 +901,6 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bcs"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "bincode"
@@ -1164,8 +1049,6 @@ version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1180,12 +1063,6 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1228,7 +1105,7 @@ version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
@@ -1446,46 +1323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "custom_debug_derive"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
- "synstructure",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1568,32 +1404,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
- "unicode-xid",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1677,33 +1492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "serde",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "merlin",
- "rand_core 0.6.4",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1512,6 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1756,15 +1543,6 @@ checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "fast_chemail"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
-dependencies = [
- "ascii_utils",
 ]
 
 [[package]]
@@ -1804,12 +1582,6 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixed-hash"
@@ -1857,62 +1629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "frunk"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874b6a17738fc273ec753618bac60ddaeac48cb1d7684c3e7bd472e57a28b817"
-dependencies = [
- "frunk_core",
- "frunk_derives",
- "frunk_proc_macros",
- "serde",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3529a07095650187788833d585c219761114005d5976185760cf794d265b6a5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "frunk_derives"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99b8b3c28ae0e84b604c75f721c21dc77afb3706076af5e8216d15fd1deaae3"
-dependencies = [
- "frunk_proc_macro_helpers",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "frunk_proc_macro_helpers"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a956ef36c377977e512e227dcad20f68c2786ac7a54dacece3746046fea5ce"
-dependencies = [
- "frunk_core",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "frunk_proc_macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e86c2c9183662713fea27ea527aad20fb15fee635a71081ff91bf93df4dc51"
-dependencies = [
- "frunk_core",
- "frunk_proc_macro_helpers",
- "quote",
- "syn 2.0.103",
 ]
 
 [[package]]
@@ -2046,36 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "genawaiter-macro",
- "genawaiter-proc-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
-
-[[package]]
-name = "genawaiter-proc-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
-dependencies = [
- "proc-macro-error 0.4.12",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,20 +1884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "handlebars"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,12 +1915,6 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.4",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2618,17 +2284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,16 +2334,6 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jobserver"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
-dependencies = [
- "getrandom 0.3.3",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2811,7 +2456,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa4f5daed39f982a1bb9d15449a28347490ad42b212f8eaa2a2a344a0dce9e9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -2935,76 +2580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "linera-base"
-version = "0.15.0"
-source = "git+https://github.com/linera-io/linera-protocol?rev=57b803201adb7071b3133948522684a980971836#57b803201adb7071b3133948522684a980971836"
-dependencies = [
- "alloy-primitives",
- "anyhow",
- "async-graphql",
- "async-graphql-derive",
- "async-trait",
- "bcs",
- "cfg-if",
- "cfg_aliases",
- "chrono",
- "custom_debug_derive",
- "derive_more 1.0.0",
- "ed25519-dalek",
- "futures",
- "hex",
- "is-terminal",
- "k256",
- "linera-witty",
- "port-selector",
- "prometheus",
- "proptest",
- "rand 0.8.5",
- "ruzstd",
- "serde",
- "serde-name",
- "serde_bytes",
- "serde_json",
- "serde_with",
- "test-strategy",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "tracing-subscriber",
- "trait-variant",
- "zstd",
-]
-
-[[package]]
-name = "linera-witty"
-version = "0.15.0"
-source = "git+https://github.com/linera-io/linera-protocol?rev=57b803201adb7071b3133948522684a980971836#57b803201adb7071b3133948522684a980971836"
-dependencies = [
- "anyhow",
- "cfg_aliases",
- "either",
- "frunk",
- "genawaiter",
- "linera-witty-macros",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "linera-witty-macros"
-version = "0.15.0"
-source = "git+https://github.com/linera-io/linera-protocol?rev=57b803201adb7071b3133948522684a980971836#57b803201adb7071b3133948522684a980971836"
-dependencies = [
- "cfg_aliases",
- "heck 0.4.1",
- "proc-macro-error 1.0.4",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,37 +2628,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3106,23 +2654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,16 +2668,6 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
 ]
 
 [[package]]
@@ -3303,12 +2824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,15 +2910,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3505,15 +3011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "port-selector"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd119ef551a50cd8939f0ff93bd062891f7b0dbb771b4a05df8a9c13aebaff68"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,56 +3055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
-dependencies = [
- "proc-macro-error-attr 0.4.12",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr 1.0.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "syn-mid",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3630,33 +3077,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot 0.12.4",
- "protobuf",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3673,17 +3099,11 @@ dependencies = [
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quick-error"
@@ -3800,44 +3220,6 @@ checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4119,15 +3501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ruzstd"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4294,25 +3667,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-name"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
-dependencies = [
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,28 +3804,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "signature"
@@ -4544,12 +3880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,48 +3902,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "static_assertions_next"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structmeta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
 
 [[package]]
 name = "strum"
@@ -4621,20 +3913,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.103",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4643,7 +3922,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4676,17 +3955,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-mid"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4741,18 +4009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-strategy"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8361c808554228ad09bfed70f5c823caf8a3450b6881cc3a38eb57e8c08c1d9"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4790,15 +4046,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.103",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -4871,7 +4118,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -5042,7 +4288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
@@ -5058,46 +4303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-serde",
-]
-
-[[package]]
-name = "trait-variant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "trim-in-place"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5108,16 +4313,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
 
 [[package]]
 name = "typenum"
@@ -5235,9 +4430,8 @@ dependencies = [
  "bincode",
  "clap",
  "config",
- "derive_more 2.0.1",
+ "derive_more",
  "jsonrpsee",
- "linera-base",
  "schemars",
  "serde",
  "serde_json",
@@ -5799,32 +4993,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.103",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/vsl-sdk/Cargo.toml
+++ b/vsl-sdk/Cargo.toml
@@ -16,7 +16,6 @@ alloy = "0.15.10"
 alloy-rlp = "0.3.12"
 derive_more = "2.0.1"
 jsonrpsee = { version = "0.25.1", features = ["client", "server", "macros"] }
-linera-base = { git = "https://github.com/linera-io/linera-protocol", rev = "57b803201adb7071b3133948522684a980971836", default-features = false, features = ["test"] }
 schemars = { version = "0.8.22", features = ["preserve_order"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1.0.140" }

--- a/vsl-sdk/examples/faucet/faucet.rs
+++ b/vsl-sdk/examples/faucet/faucet.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use tokio::time::sleep;
 use vsl_sdk::{
     Address, Amount, IntoSigned, Timestamp,
-    rpc_wrapper::{self, RpcWrapper, RpcWrapperResult, format_amount, parse_amount},
+    rpc_wrapper::{self, RpcWrapper, RpcWrapperResult},
 };
 
 const LOOP_INTERVAL: u64 = 5; // seconds
@@ -108,7 +108,7 @@ pub async fn main() -> RpcWrapperResult<()> {
                 continue;
             };
             let amount = &settled_claim.verified_claim.claim;
-            let Ok(amount) = parse_amount(amount) else {
+            let Ok(amount) = Amount::from_hex_str(amount) else {
                 eprintln!("Cannot parse the requested amount: {}", amount);
                 continue;
             };
@@ -124,14 +124,14 @@ pub async fn main() -> RpcWrapperResult<()> {
             let Ok(response) = account.pay(&faucet_client, &amount).await else {
                 eprintln!(
                     "Error while transfering amount '{}' to client '{}'",
-                    format_amount(amount),
+                    amount,
                     faucet_client
                 );
                 continue;
             };
             eprintln!(
                 "Payed {} to {} (transaction id: {})",
-                format_amount(amount),
+                amount,
                 faucet_client,
                 response
             );

--- a/vsl-sdk/examples/faucet/faucet_verifier.rs
+++ b/vsl-sdk/examples/faucet/faucet_verifier.rs
@@ -8,7 +8,7 @@ use sled::{Db, IVec};
 use vsl_sdk::{
     Address, Amount, B256, HasSender, IntoSigned, Timestamp,
     rpc_messages::{IdentifiableClaim, PayMessage, SubmittedClaim},
-    rpc_wrapper::{self, RpcWrapper, RpcWrapperResult, parse_amount},
+    rpc_wrapper::{self, RpcWrapper, RpcWrapperResult},
 };
 
 /// Example Faucet verifier for the VSL devnet
@@ -145,7 +145,7 @@ pub async fn main() -> RpcWrapperResult<()> {
             eprintln!("Invalid client address");
             continue;
         };
-        let Ok(amount) = parse_amount(&request.claim) else {
+        let Ok(amount) = Amount::from_hex_str(&request.claim) else {
             eprintln!("Cannot parse the requested amount: {}", request.claim);
             continue;
         };

--- a/vsl-sdk/src/lib.rs
+++ b/vsl-sdk/src/lib.rs
@@ -4,10 +4,102 @@ pub mod rpc_wrapper;
 mod helpers;
 mod timestamp;
 
+use std::{fmt::Display, num::ParseIntError};
+
 pub use crate::helpers::{HasSender, IntoSigned};
 pub use alloy::primitives::{Address, B256};
-pub use linera_base::data_types::Amount;
-pub use linera_base::identifiers::ApplicationId as AssetId;
 pub use timestamp::Timestamp;
 
 pub mod rpc_service;
+
+#[derive(Debug)]
+pub enum ParseAmountError {
+    NotHex,
+    LeadingZeros,
+    ParseInt(ParseIntError),
+}
+
+impl ToString for ParseAmountError {
+    fn to_string(&self) -> String {
+        match self {
+            ParseAmountError::NotHex => "Amount should start with 0x".to_string(),
+            ParseAmountError::LeadingZeros => "Amount should not start with 0x0".to_string(),
+            ParseAmountError::ParseInt(parse_int_error) => parse_int_error.to_string(),
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
+pub struct Amount {
+    subunits: u128,
+    decimals: u8,
+}
+
+impl Amount {
+    pub fn decimals(&self) -> u8 {
+        self.decimals
+    }
+
+    pub fn subunits(&self) -> u128 {
+        self.subunits
+    }
+
+    pub fn from_tokens(tokens: u128) -> Self {
+        Self::from_tokens_with_decimals(tokens, 18)
+    }
+
+    pub fn from_subunits(subunits: u128) -> Self {
+        Self::from_tokens_with_decimals(subunits, 18)
+    }
+
+    pub fn from_subunits_with_decimanls(subunits: u128, decimals: u8) -> Self {
+        Self { subunits, decimals }
+    }
+
+    pub fn from_tokens_with_decimals(tokens: u128, decimals: u8) -> Self {
+        let multiplier = 10_u128.checked_pow(decimals as u32).unwrap();
+        let coins = tokens.checked_mul(multiplier).unwrap_or_else(||
+            panic!("Speficied amount cannot be represented")
+        );
+        Self::from_subunits_with_decimanls(coins, decimals)
+    }
+
+    pub fn from_hex_str(s: &str) -> Result<Self, ParseAmountError> {
+        Self::from_hex_str_with_decimals(s, 18)
+    }
+
+    pub fn from_hex_str_with_decimals(s: &str, decimals: u8) -> Result<Self, ParseAmountError> {
+        if !s.starts_with("0x") {
+            return Err(ParseAmountError::NotHex)
+        }
+        let s = &s[2..];
+        let subunits = 
+        if s == "0" {
+            0
+        } else if s.starts_with('0') {
+            return Err(ParseAmountError::LeadingZeros);
+        } else {
+            u128::from_str_radix(s, 16).map_err(ParseAmountError::ParseInt)?
+        };
+        Ok(Self { subunits, decimals })
+    }
+
+    pub fn to_hex_string(&self) -> String {
+        format!("{:#x}", self.subunits)
+    }
+}
+
+impl From<Amount> for u128 {
+    fn from(value: Amount) -> Self {
+        value.subunits
+    }
+}
+
+impl Display for Amount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let multiplier = 10_u128.checked_pow(self.decimals as u32).unwrap();
+        let units = self.subunits / multiplier;
+        let subunits = self.subunits % multiplier;
+        f.write_fmt(format_args!("{}.{:0>width$}", units, subunits, width = self.decimals as usize))
+    }
+}

--- a/vsl-sdk/src/rpc_wrapper.rs
+++ b/vsl-sdk/src/rpc_wrapper.rs
@@ -9,73 +9,13 @@ use alloy::signers::local::PrivateKeySigner;
 use jsonrpsee::core::client::{ClientT, Error as RpcError, Subscription, SubscriptionClientT};
 use jsonrpsee::rpc_params;
 use jsonrpsee::ws_client::WsClient;
-use linera_base::BcsHexParseError;
 
 use crate::helpers::IntoSigned;
 use crate::rpc_messages::{
     AccountStateHash, CreateAssetMessage, IdentifiableClaim as _, PayMessage, SetStateMessage,
     SettleClaimMessage, SettledVerifiedClaim, SubmittedClaim, Timestamped, TransferAssetMessage,
 };
-use crate::{Address, Amount, AssetId, B256, Timestamp};
-
-pub fn format_amount(amount: Amount) -> String {
-    format!("{:#x}", u128::from(amount))
-}
-
-pub fn format_token_amount(amount: Amount, decimals: u8) -> RpcWrapperResult<String> {
-    assert!(decimals <= 18);
-    let mut atto_amount = u128::from(amount);
-    if decimals != 18 {
-        // Amount is using 18 decimals; scale to fit token amount decimals
-        let multiplier: u128 = 10_u128.checked_pow(18 - decimals as u32).unwrap();
-        let remainder = atto_amount % multiplier;
-        atto_amount /= multiplier;
-        if remainder != 0 {
-            return Err(RpcWrapperError::AmountError(
-                "Amount uses more decimals than allowed.".to_string(),
-            ));
-        }
-    }
-    Ok(format!("{:#x}", atto_amount))
-}
-
-pub fn parse_amount(s: &str) -> RpcWrapperResult<Amount> {
-    parse_token_amount(s, 18)
-}
-
-pub fn parse_token_amount(s: &str, decimals: u8) -> RpcWrapperResult<Amount> {
-    assert!(decimals <= 18);
-    if !s.starts_with("0x") {
-        return Err(RpcWrapperError::AmountError(
-            "Amount should start with 0x".to_string(),
-        ));
-    }
-    let s = &s[2..];
-    if s == "0" {
-        return Ok(Amount::ZERO);
-    }
-    if s.starts_with('0') {
-        return Err(RpcWrapperError::AmountError(
-            "Amount should not start with 0x0".to_string(),
-        ));
-    } else {
-        let mut attos =
-            u128::from_str_radix(s, 16).map_err(|e| RpcWrapperError::AmountError(e.to_string()))?;
-        if decimals != 18 {
-            // Amount is using 18 decimals; scale token amount to fit that
-            let multiplier = 10_u128.checked_pow(18 - decimals as u32).unwrap();
-            attos = match attos.checked_mul(multiplier) {
-                None => {
-                    return Err(RpcWrapperError::AmountError(
-                        "Speficied amount cannot be represented".to_string(),
-                    ));
-                }
-                Some(n) => n,
-            };
-        }
-        return Ok(Amount::from_attos(attos));
-    }
-}
+use crate::{Address, Amount, ParseAmountError, Timestamp, B256};
 
 /// Metadata about an asset
 pub struct AssetData {
@@ -112,7 +52,7 @@ impl TryFrom<CreateAssetMessage> for AssetData {
                 "Cannot parse nonce".to_string(),
             ));
         };
-        let total_supply = parse_token_amount(&total_supply, decimals)?;
+        let total_supply = Amount::from_hex_str_with_decimals(&total_supply, decimals)?;
         Ok(Self {
             account_id,
             nonce,
@@ -123,17 +63,16 @@ impl TryFrom<CreateAssetMessage> for AssetData {
     }
 }
 
-impl TryInto<CreateAssetMessage> for AssetData {
-    type Error = RpcWrapperError;
+impl Into<CreateAssetMessage> for AssetData {
 
-    fn try_into(self) -> Result<CreateAssetMessage, Self::Error> {
-        Ok(CreateAssetMessage {
+    fn into(self) -> CreateAssetMessage {
+        CreateAssetMessage {
             account_id: self.account_id.to_string(),
             nonce: self.nonce.to_string(),
             ticker_symbol: self.ticker_symbol,
             decimals: self.decimals,
-            total_supply: format_token_amount(self.total_supply, self.decimals)?,
-        })
+            total_supply: self.total_supply.to_hex_string(),
+        }
     }
 }
 
@@ -142,10 +81,10 @@ pub enum RpcWrapperError {
     RpcError(RpcError),
     FromHexError(FromHexError),
     SignError(SignError),
-    AmountError(String),
-    AssetError(BcsHexParseError),
+    AmountError(ParseAmountError),
     ParseError(String),
     NonExistentAsset,
+    InvalidAmount,
 }
 
 impl From<RpcError> for RpcWrapperError {
@@ -166,9 +105,9 @@ impl From<SignError> for RpcWrapperError {
     }
 }
 
-impl From<BcsHexParseError> for RpcWrapperError {
-    fn from(value: BcsHexParseError) -> Self {
-        Self::AssetError(value)
+impl From<ParseAmountError> for RpcWrapperError {
+    fn from(value: ParseAmountError) -> Self {
+        Self::AmountError(value)
     }
 }
 
@@ -279,7 +218,7 @@ where
             quorum,
             from: self.address().to_string(),
             expires,
-            fee: format_amount(fee),
+            fee: fee.to_hex_string(),
         };
         let claim = self.sign(submitted_claim)?;
         let response: String = self
@@ -329,7 +268,7 @@ where
             from: self.address().to_string(),
             nonce: self.nonce().to_string(),
             to: to.to_string(),
-            amount: format_amount(*amount),
+            amount: amount.to_hex_string(),
         };
         let signed_claim = self.sign(pay_message)?;
         let response: String = self
@@ -357,16 +296,16 @@ where
         ticker_symbol: &str,
         decimals: u8,
         total_supply: &Amount,
-    ) -> RpcWrapperResult<AssetId> {
+    ) -> RpcWrapperResult<String> {
         let create_asset_message =
-            self.create_asset_message(ticker_symbol, decimals, total_supply)?;
+            self.create_asset_message(ticker_symbol, decimals, total_supply);
         let signed_claim = self.sign(create_asset_message)?;
         let response: String = self
             .rpc_client
             .request("vsl_createAsset", rpc_params![signed_claim])
             .await?;
         self.inc_nonce();
-        Ok(AssetId::from_str(&response)?)
+        Ok(response)
     }
 
     pub fn create_asset_message(
@@ -374,7 +313,7 @@ where
         ticker_symbol: &str,
         decimals: u8,
         total_supply: &Amount,
-    ) -> RpcWrapperResult<CreateAssetMessage> {
+    ) -> CreateAssetMessage {
         AssetData {
             account_id: self.address,
             nonce: self.nonce,
@@ -382,7 +321,7 @@ where
             decimals,
             total_supply: *total_supply,
         }
-        .try_into()
+        .into()
     }
 
     /// Transfers a specific asset from one account to another.
@@ -403,15 +342,18 @@ where
     /// - `amount` uses more decimals than allowed by the asset metadata
     pub async fn transfer_asset(
         &mut self,
-        asset_id: &AssetId,
+        asset_id: &str,
         to: &Address,
         amount: &Amount,
     ) -> RpcWrapperResult<B256> {
         let Some(asset_data) = self.get_asset_by_id(asset_id).await? else {
             return Err(RpcWrapperError::NonExistentAsset);
         };
+        if amount.decimals != asset_data.decimals {
+            return Err(RpcWrapperError::InvalidAmount);
+        }
         let transfer_asset_message =
-            self.transfer_asset_message(asset_id, to, amount, asset_data.decimals)?;
+            self.transfer_asset_message(asset_id, to, amount)?;
         let signed_claim = self.sign(transfer_asset_message)?;
         let response: String = self
             .rpc_client
@@ -423,16 +365,15 @@ where
 
     pub fn transfer_asset_message(
         &self,
-        asset_id: &AssetId,
+        asset_id: &str,
         to: &Address,
         amount: &Amount,
-        decimals: u8,
     ) -> RpcWrapperResult<TransferAssetMessage> {
         Ok(TransferAssetMessage {
             from: self.address().to_string(),
             nonce: self.nonce().to_string(),
             to: to.to_string(),
-            amount: format_token_amount(*amount, decimals)?,
+            amount: amount.to_hex_string(),
             asset_id: asset_id.to_string(),
         })
     }
@@ -486,14 +427,14 @@ where
     ///
     /// - Input: the asset ID to query.
     /// - Returns: the asset balance
-    pub async fn get_asset_balance(&self, asset_id: &AssetId) -> RpcWrapperResult<Amount> {
+    pub async fn get_asset_balance(&self, asset_id: &str) -> RpcWrapperResult<Amount> {
         get_asset_balance(self.rpc_client(), self.address(), asset_id).await
     }
 
     /// Retrieves the balances of all assets held by the wrapped account.
     ///
     /// - Returns: a map of asset IDs to balances
-    pub async fn get_asset_balances(&self) -> RpcWrapperResult<HashMap<AssetId, Amount>> {
+    pub async fn get_asset_balances(&self) -> RpcWrapperResult<HashMap<String, Amount>> {
         get_asset_balances(self.rpc_client(), self.address()).await
     }
 
@@ -502,7 +443,7 @@ where
     /// - Input: the asset ID to query.
     /// - Returns: An [AssetData] containing information about the asset,
     ///   or `None` if no asset with that id was created.
-    pub async fn get_asset_by_id(&self, asset_id: &AssetId) -> RpcWrapperResult<Option<AssetData>> {
+    pub async fn get_asset_by_id(&self, asset_id: &str) -> RpcWrapperResult<Option<AssetData>> {
         get_asset_by_id(self.rpc_client(), asset_id).await
     }
 
@@ -664,7 +605,7 @@ pub async fn get_balance<T: ClientT>(
     let response: String = rpc_client
         .request("vsl_getBalance", rpc_params![address.to_string()])
         .await?;
-    parse_amount(&response)
+    Ok(Amount::from_hex_str(&response)?)
 }
 
 /// Retrieves the balance of a specific asset held by an account.
@@ -675,7 +616,7 @@ pub async fn get_balance<T: ClientT>(
 pub async fn get_asset_balance<T: ClientT>(
     rpc_client: &T,
     account_id: &Address,
-    asset_id: &AssetId,
+    asset_id: &str,
 ) -> RpcWrapperResult<Amount> {
     let Some(asset_data) = get_asset_by_id(rpc_client, asset_id).await? else {
         return Err(RpcWrapperError::NonExistentAsset);
@@ -683,10 +624,10 @@ pub async fn get_asset_balance<T: ClientT>(
     let response: String = rpc_client
         .request(
             "vsl_getAssetBalance",
-            rpc_params![account_id.to_string(), asset_id.to_string()],
+            rpc_params![account_id.to_string(), asset_id],
         )
         .await?;
-    parse_token_amount(&response, asset_data.decimals)
+    Ok(Amount::from_hex_str_with_decimals(&response, asset_data.decimals)?)
 }
 
 /// Retrieves the balances of all assets held by an account.
@@ -696,17 +637,16 @@ pub async fn get_asset_balance<T: ClientT>(
 pub async fn get_asset_balances<T: ClientT>(
     rpc_client: &T,
     account_id: &Address,
-) -> RpcWrapperResult<HashMap<AssetId, Amount>> {
+) -> RpcWrapperResult<HashMap<String, Amount>> {
     let response: HashMap<String, String> = rpc_client
         .request("vsl_getAssetBalances", rpc_params![account_id.to_string()])
         .await?;
     let mut result = HashMap::with_capacity(response.len());
     for (asset_id, amount) in response {
-        let asset_id = AssetId::from_str(&asset_id)?;
         let Some(asset_data) = get_asset_by_id(rpc_client, &asset_id).await? else {
             return Err(RpcWrapperError::NonExistentAsset);
         };
-        result.insert(asset_id, parse_token_amount(&amount, asset_data.decimals)?);
+        result.insert(asset_id, Amount::from_hex_str_with_decimals(&amount, asset_data.decimals)?);
     }
     Ok(result)
 }
@@ -718,10 +658,10 @@ pub async fn get_asset_balances<T: ClientT>(
 ///   or `None` if no asset with that id was created.
 pub async fn get_asset_by_id<T: ClientT>(
     rpc_client: &T,
-    asset_id: &AssetId,
+    asset_id: &str,
 ) -> RpcWrapperResult<Option<AssetData>> {
     let response: Option<CreateAssetMessage> = rpc_client
-        .request("vsl_getAssetById", rpc_params![asset_id.to_string()])
+        .request("vsl_getAssetById", rpc_params![asset_id])
         .await?;
     let Some(response) = response else {
         return Ok(None);


### PR DESCRIPTION
Probably the `parse_amount` and `format_amount` functions should be moved for now in the vsl repo in the vsl_utils.