### PR TITLE
endpoints to improve Explorer efficiency

### DIFF
--- a/docs/api/SettledClaimData.json
+++ b/docs/api/SettledClaimData.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SettledClaimData",
+  "description": "Metadata for a settled (verified) claim",
+  "type": "object",
+  "required": [
+    "claim_owner",
+    "claim_type",
+    "verifiers"
+  ],
+  "properties": {
+    "claim_type": {
+      "description": "the claim type",
+      "type": "string"
+    },
+    "claim_owner": {
+      "description": "the (Ethereum-style) address of the client which produced this claim",
+      "type": "string"
+    },
+    "verifiers": {
+      "description": "the (Ethereum-style) addresses of the verifiers which have verified the claim and are part of the quorum",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/docs/api/SubmittedClaimData.json
+++ b/docs/api/SubmittedClaimData.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SubmittedClaimData",
+  "description": "Metadata for a settled (verified) claim",
+  "type": "object",
+  "required": [
+    "claim_type",
+    "expires",
+    "fee",
+    "from",
+    "nonce",
+    "quorum",
+    "to"
+  ],
+  "properties": {
+    "claim_type": {
+      "description": "the claim type (could be any string)",
+      "type": "string"
+    },
+    "nonce": {
+      "description": "the client nonce (64 bit unsigned integer)",
+      "type": "string"
+    },
+    "to": {
+      "description": "the list of (Ethereum-style) addresses of accounts which can verify this claim",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "quorum": {
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "from": {
+      "type": "string"
+    },
+    "expires": {
+      "$ref": "#/definitions/Timestamp"
+    },
+    "fee": {
+      "description": "the fee for verification (u128 formatted as hex string).",
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "Timestamp": {
+      "description": "Records the time elapsed from the [UNIX_EPOCH]",
+      "type": "object",
+      "required": [
+        "nanos",
+        "seconds"
+      ],
+      "properties": {
+        "seconds": {
+          "description": "Time elapsed from the [UNIX_EPOCH] (in seconds, truncated)",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "nanos": {
+          "description": "the _remaining fraction_ of a second, expressed in nano-seconds",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    }
+  }
+}

--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -4,10 +4,14 @@
 
 - [`vsl_submitClaim`](#vsl_submitclaim)
 - [`vsl_settleClaim`](#vsl_settleclaim)
+- [`vsl_listSettledClaimsMetadata`](#vsl_listsettledclaimsmetadata)
+- [`vsl_listSubmittedClaimsMetadata`](#vsl_listsubmittedclaimsmetadata)
 - [`vsl_listSettledClaimsForReceiver`](#vsl_listsettledclaimsforreceiver)
 - [`vsl_listSubmittedClaimsForReceiver`](#vsl_listsubmittedclaimsforreceiver)
 - [`vsl_listSettledClaimsForSender`](#vsl_listsettledclaimsforsender)
 - [`vsl_listSubmittedClaimsForSender`](#vsl_listsubmittedclaimsforsender)
+- [`vsl_getClaimDataById`](#vsl_getclaimdatabyid)
+- [`vsl_getProofById`](#vsl_getproofbyid)
 - [`vsl_getSettledClaimById`](#vsl_getsettledclaimbyid)
 - [`vsl_pay`](#vsl_pay)
 - [`vsl_getAccount`](#vsl_getaccount)
@@ -86,6 +90,40 @@ Will fail if:
 **Returns**:
 
 String
+
+---
+
+## `vsl_listSettledClaimsMetadata`
+
+Yields (recent) settled claims metadata
+
+- Input: a [Timestamp](#timestamp) (`since`)
+- Returns: a list containing metadata for the most recent settled claims recorded since the given timestamp (limited at 64 entries).
+
+**Parameters**:
+
+- `since`: [Timestamp](#timestamp)
+
+**Returns**:
+
+Vec< [Timestamped](#timestamped)< [SettledClaimData](#settledclaimdata) > >
+
+---
+
+## `vsl_listSubmittedClaimsMetadata`
+
+Yields (recent) submitted claims metadata
+
+- Input: a [Timestamp](#timestamp) (`since`)
+- Returns: a list containing metadata for the most recent submitted claims recorded since the given timestamp (limited at 64 entries).
+
+**Parameters**:
+
+- `since`: [Timestamp](#timestamp)
+
+**Returns**:
+
+Vec< [Timestamped](#timestamped)< [SubmittedClaimData](#submittedclaimdata) > >
 
 ---
 
@@ -178,6 +216,48 @@ Will fail if:
 **Returns**:
 
 Vec< [Timestamped](#timestamped)< Signed< [SubmittedClaim](#submittedclaim) > > >
+
+---
+
+## `vsl_getClaimDataById`
+
+Retrieves the claim data contained in the submitted claim with the given ID.
+
+- Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+- Returns: the contents of the `claim` field from the corresponding [SubmittedClaim](#submittedclaim).
+
+Will fail if:
+
+- no claim with given ID is not found among the submitted claims
+
+**Parameters**:
+
+- `claim_id`: String
+
+**Returns**:
+
+String
+
+---
+
+## `vsl_getProofById`
+
+Retrieves the proof contained in the submitted claim with the given ID.
+
+- Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+- Returns: the contents of the `proof` field from the corresponding [SubmittedClaim](#submittedclaim).
+
+Will fail if:
+
+- no claim with given ID is not found among the submitted claims
+
+**Parameters**:
+
+- `claim_id`: String
+
+**Returns**:
+
+String
 
 ---
 
@@ -523,6 +603,28 @@ An (unsigned) vls_submitClaim request for claim-verification
 
 - **to** (array< string >): the list of (Ethereum-style) addresses of accounts which can verify this claim
 
+## SubmittedClaimData
+
+Metadata for a settled (verified) claim
+
+**JSON Schema**: [SubmittedClaimData](SubmittedClaimData.json)
+
+### Fields:
+
+- **claim_type** (string): the claim type (could be any string)
+
+- **expires** ([Timestamp](timestamp))
+
+- **fee** (string): the fee for verification (u128 formatted as hex string).
+
+- **from** (string)
+
+- **nonce** (string): the client nonce (64 bit unsigned integer)
+
+- **quorum** (integer)
+
+- **to** (array< string >): the list of (Ethereum-style) addresses of accounts which can verify this claim
+
 ## VerifiedClaim
 
 Representation of a verified claim
@@ -562,6 +664,20 @@ A settled (verified) claim
 ### Fields:
 
 - **verified_claim** ([VerifiedClaim](verifiedclaim)): the claim which was verified
+
+- **verifiers** (array< string >): the (Ethereum-style) addresses of the verifiers which have verified the claim and are part of the quorum
+
+## SettledClaimData
+
+Metadata for a settled (verified) claim
+
+**JSON Schema**: [SettledClaimData](SettledClaimData.json)
+
+### Fields:
+
+- **claim_owner** (string): the (Ethereum-style) address of the client which produced this claim
+
+- **claim_type** (string): the claim type
 
 - **verifiers** (array< string >): the (Ethereum-style) addresses of the verifiers which have verified the claim and are part of the quorum
 

--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -25,6 +25,8 @@
 - [`vsl_setAccountState`](#vsl_setaccountstate)
 - [`vsl_getAccountNonce`](#vsl_getaccountnonce)
 - [`vsl_getHealth`](#vsl_gethealth)
+- [`vsl_subscribeToSettledClaimsMetadata`](#vsl_subscribetosettledclaimsmetadata)
+- [`vsl_subscribeToSubmittedClaimsMetadata`](#vsl_subscribetosubmittedclaimsmetadata)
 - [`vsl_subscribeToSettledClaimsForReceiver`](#vsl_subscribetosettledclaimsforreceiver)
 - [`vsl_subscribeToSubmittedClaimsForReceiver`](#vsl_subscribetosubmittedclaimsforreceiver)
 
@@ -540,6 +542,30 @@ Checks if the server is up and ready.
 **Returns**:
 
 String
+
+---
+
+## `vsl_subscribeToSettledClaimsMetadata`
+
+[Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the settled claims metadata
+
+- yields: a stream of timestamped [SettledClaimData](#settledclaimdata)s
+
+**Returns**:
+
+SubscriptionResult
+
+---
+
+## `vsl_subscribeToSubmittedClaimsMetadata`
+
+[Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the claim verification requests metadata
+
+- yields: a stream of timestamped [SubmittedClaimData](#submittedclaimdata)s
+
+**Returns**:
+
+SubscriptionResult
 
 ---
 

--- a/docs/api/rpc.md
+++ b/docs/api/rpc.md
@@ -12,6 +12,7 @@
 - [`vsl_listSubmittedClaimsForSender`](#vsl_listsubmittedclaimsforsender)
 - [`vsl_getClaimDataById`](#vsl_getclaimdatabyid)
 - [`vsl_getProofById`](#vsl_getproofbyid)
+- [`vsl_getSubmittedClaimById`](#vsl_getsubmittedclaimbyid)
 - [`vsl_getSettledClaimById`](#vsl_getsettledclaimbyid)
 - [`vsl_pay`](#vsl_pay)
 - [`vsl_getAccount`](#vsl_getaccount)
@@ -260,6 +261,27 @@ Will fail if:
 **Returns**:
 
 String
+
+---
+
+## `vsl_getSubmittedClaimById`
+
+Retrieves a submitted claim by its unique claim ID.
+
+- Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+- Returns: the timestamped and signed [SubmittedClaim](#submittedclaim) claim corresponding to the given claim ID.
+
+Will fail if:
+
+- claim is not found among the submitted claims
+
+**Parameters**:
+
+- `claim_id`: String
+
+**Returns**:
+
+[Timestamped](#timestamped)< Signed< [SubmittedClaim](#submittedclaim) > >
 
 ---
 

--- a/vsl-sdk/src/rpc_messages.rs
+++ b/vsl-sdk/src/rpc_messages.rs
@@ -107,6 +107,84 @@ pub struct VerifiedClaim {
 
 impl HasSender for VerifiedClaim {}
 
+/// Metadata for a settled (verified) claim
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, RlpEncodable, RlpDecodable)]
+pub struct SettledClaimData {
+    /// the claim type
+    pub claim_type: String,
+    /// the (Ethereum-style) address of the client which produced this claim
+    pub claim_owner: String,
+    /// the (Ethereum-style) addresses of the verifiers which have verified the claim and are part of the quorum
+    pub verifiers: Vec<String>,
+}
+
+impl From<SettledVerifiedClaim> for SettledClaimData {
+    fn from(value: SettledVerifiedClaim) -> Self {
+        Self {
+            claim_type: value.verified_claim.claim_type,
+            claim_owner: value.verified_claim.claim_owner,
+            verifiers: value.verifiers,
+        }
+    }
+}
+
+impl From<&SettledVerifiedClaim> for SettledClaimData {
+    fn from(value: &SettledVerifiedClaim) -> Self {
+        Self {
+            claim_type: value.verified_claim.claim_type.clone(),
+            claim_owner: value.verified_claim.claim_owner.clone(),
+            verifiers: value.verifiers.clone(),
+        }
+    }
+}
+
+/// Metadata for a settled (verified) claim
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, RlpEncodable, RlpDecodable)]
+pub struct SubmittedClaimData {
+    /// the claim type (could be any string)
+    pub claim_type: String,
+    /// the client nonce (64 bit unsigned integer)
+    pub nonce: String,
+    /// the list of (Ethereum-style) addresses of accounts which can verify this claim
+    pub to: Vec<String>,
+    //the minimum quorum of signatures
+    pub quorum: u16,
+    // the (Ethereum-style) address of the client account requesting verification
+    pub from: String,
+    // the time after which the claim is dropped if not enough verifications are received
+    pub expires: Timestamp,
+    /// the fee for verification (u128 formatted as hex string).
+    pub fee: String,
+}
+
+impl From<SubmittedClaim> for SubmittedClaimData {
+    fn from(value: SubmittedClaim) -> Self {
+        Self {
+            claim_type: value.claim_type,
+            nonce: value.nonce,
+            to: value.to,
+            quorum: value.quorum,
+            from: value.from,
+            expires: value.expires,
+            fee: value.fee,
+        }
+    }
+}
+
+impl From<&SubmittedClaim> for SubmittedClaimData {
+    fn from(value: &SubmittedClaim) -> Self {
+        Self {
+            claim_type: value.claim_type.clone(),
+            nonce: value.nonce.clone(),
+            to: value.to.clone(),
+            quorum: value.quorum,
+            from: value.from.clone(),
+            expires: value.expires,
+            fee: value.fee.clone(),
+        }
+    }
+}
+
 /// A settled (verified) claim
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, RlpEncodable, RlpDecodable)]
 pub struct SettledVerifiedClaim {

--- a/vsl-sdk/src/rpc_messages.rs
+++ b/vsl-sdk/src/rpc_messages.rs
@@ -139,7 +139,7 @@ impl From<&SettledVerifiedClaim> for SettledClaimData {
     }
 }
 
-/// Metadata for a settled (verified) claim
+/// Metadata for a submitted claim
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, RlpEncodable, RlpDecodable)]
 pub struct SubmittedClaimData {
     /// the claim type (could be any string)

--- a/vsl-sdk/src/rpc_messages.rs
+++ b/vsl-sdk/src/rpc_messages.rs
@@ -1,6 +1,7 @@
 use alloy::consensus::transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
+use alloy::consensus::Signed;
 use alloy::eips::Typed2718;
-use alloy::primitives::{Address, B256, Keccak256, keccak256, wrap_fixed_bytes};
+use alloy::primitives::{keccak256, wrap_fixed_bytes, Address, Keccak256, B256};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -182,6 +183,19 @@ impl From<&SubmittedClaim> for SubmittedClaimData {
             expires: value.expires,
             fee: value.fee.clone(),
         }
+    }
+}
+
+impl<'a, T1, T2> From<&'a Timestamped<Signed<T1>>> for Timestamped<T2>
+where
+  T2 : From<&'a T1>,
+{
+    fn from(ts: &'a Timestamped<Signed<T1>>) -> Self {
+        Timestamped {
+            id: ts.id.clone(),
+            data: T2::from(ts.data.tx()),
+            timestamp: ts.timestamp,
+        }        
     }
 }
 

--- a/vsl-sdk/src/rpc_messages.rs
+++ b/vsl-sdk/src/rpc_messages.rs
@@ -1,7 +1,7 @@
-use alloy::consensus::transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 use alloy::consensus::Signed;
+use alloy::consensus::transaction::{RlpEcdsaDecodableTx, RlpEcdsaEncodableTx};
 use alloy::eips::Typed2718;
-use alloy::primitives::{keccak256, wrap_fixed_bytes, Address, Keccak256, B256};
+use alloy::primitives::{Address, B256, Keccak256, keccak256, wrap_fixed_bytes};
 use alloy_rlp::{Decodable, Encodable, RlpDecodable, RlpEncodable};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -188,14 +188,14 @@ impl From<&SubmittedClaim> for SubmittedClaimData {
 
 impl<'a, T1, T2> From<&'a Timestamped<Signed<T1>>> for Timestamped<T2>
 where
-  T2 : From<&'a T1>,
+    T2: From<&'a T1>,
 {
     fn from(ts: &'a Timestamped<Signed<T1>>) -> Self {
         Timestamped {
             id: ts.id.clone(),
             data: T2::from(ts.data.tx()),
             timestamp: ts.timestamp,
-        }        
+        }
     }
 }
 

--- a/vsl-sdk/src/rpc_service.rs
+++ b/vsl-sdk/src/rpc_service.rs
@@ -160,6 +160,20 @@ pub trait ClaimRpc {
     #[method(name = "vsl_getProofById", param_kind = map)]
     async fn get_proof_by_id(&self, claim_id: String) -> RpcResult<String>;
 
+    /// Retrieves a submitted claim by its unique claim ID.
+    ///
+    /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+    /// - Returns: the timestamped and signed [SubmittedClaim] claim corresponding to the given claim ID.
+    ///
+    /// Will fail if:
+    ///
+    /// - claim is not found among the submitted claims
+    #[method(name = "vsl_getSubmittedClaimById", param_kind = map)]
+    async fn get_submitted_claim_by_id(
+        &self,
+        claim_id: String,
+    ) -> RpcResult<Timestamped<Signed<SubmittedClaim>>>;
+
     /// Retrieves a settled claim by its unique claim ID.
     ///
     /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.

--- a/vsl-sdk/src/rpc_service.rs
+++ b/vsl-sdk/src/rpc_service.rs
@@ -4,7 +4,9 @@ use jsonrpsee::proc_macros::rpc;
 
 use crate::Timestamp;
 use crate::rpc_messages::{
-    CreateAssetMessage, CreateAssetResult, PayMessage, SetStateMessage, SettleClaimMessage, SettledClaimData, SettledVerifiedClaim, SubmittedClaim, SubmittedClaimData, Timestamped, TransferAssetMessage
+    CreateAssetMessage, CreateAssetResult, PayMessage, SetStateMessage, SettleClaimMessage,
+    SettledClaimData, SettledVerifiedClaim, SubmittedClaim, SubmittedClaimData, Timestamped,
+    TransferAssetMessage,
 };
 
 #[rpc(server, client)]
@@ -71,8 +73,6 @@ pub trait ClaimRpc {
         &self,
         since: Timestamp,
     ) -> RpcResult<Vec<Timestamped<SubmittedClaimData>>>;
-
-
 
     /// Yields (recent) settled claims for a receiver.
     ///
@@ -147,10 +147,7 @@ pub trait ClaimRpc {
     ///
     /// - no claim with given ID is not found among the submitted claims
     #[method(name = "vsl_getClaimDataById", param_kind = map)]
-    async fn get_claim_data_by_id(
-        &self,
-        claim_id: String,
-    ) -> RpcResult<String>;
+    async fn get_claim_data_by_id(&self, claim_id: String) -> RpcResult<String>;
 
     /// Retrieves the proof contained in the submitted claim with the given ID.
     ///
@@ -161,10 +158,7 @@ pub trait ClaimRpc {
     ///
     /// - no claim with given ID is not found among the submitted claims
     #[method(name = "vsl_getProofById", param_kind = map)]
-    async fn get_proof_by_id(
-        &self,
-        claim_id: String,
-    ) -> RpcResult<String>;
+    async fn get_proof_by_id(&self, claim_id: String) -> RpcResult<String>;
 
     /// Retrieves a settled claim by its unique claim ID.
     ///
@@ -341,9 +335,7 @@ pub trait ClaimRpc {
         unsubscribe = "vsl_unsubscribeFromSettledClaimsMetadata",
         param_kind = map,
         item = Timestamped<SettledClaimData>)]
-    async fn subscribe_to_settled_claims_metadata(
-        &self,
-    ) -> SubscriptionResult;
+    async fn subscribe_to_settled_claims_metadata(&self) -> SubscriptionResult;
 
     /// [Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the claim verification requests metadata
     ///
@@ -353,9 +345,7 @@ pub trait ClaimRpc {
         unsubscribe = "vsl_unsubscribeFromSubmittedMetadata",
         param_kind = map,
         item = Timestamped<SubmittedClaimData>)]
-    async fn subscribe_to_submitted_claims_metadata(
-        &self,
-    ) -> SubscriptionResult;
+    async fn subscribe_to_submitted_claims_metadata(&self) -> SubscriptionResult;
 
     /// [Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the settled claims for a receiver
     ///

--- a/vsl-sdk/src/rpc_service.rs
+++ b/vsl-sdk/src/rpc_service.rs
@@ -4,8 +4,7 @@ use jsonrpsee::proc_macros::rpc;
 
 use crate::Timestamp;
 use crate::rpc_messages::{
-    CreateAssetMessage, CreateAssetResult, PayMessage, SetStateMessage, SettleClaimMessage,
-    SettledVerifiedClaim, SubmittedClaim, Timestamped, TransferAssetMessage,
+    CreateAssetMessage, CreateAssetResult, PayMessage, SetStateMessage, SettleClaimMessage, SettledClaimData, SettledVerifiedClaim, SubmittedClaim, SubmittedClaimData, Timestamped, TransferAssetMessage
 };
 
 #[rpc(server, client)]
@@ -52,6 +51,28 @@ pub trait ClaimRpc {
     ///   - has already verified the claim
     #[method(name = "vsl_settleClaim", param_kind = map)]
     async fn settle_claim(&self, settled_claim: Signed<SettleClaimMessage>) -> RpcResult<String>;
+
+    /// Yields (recent) settled claims metadata
+    ///
+    /// - Input: a [Timestamp] (`since`)
+    /// - Returns: a list containing metadata for the most recent settled claims recorded since the given timestamp (limited at 64 entries).
+    #[method(name = "vsl_listSettledClaimsMetadata", param_kind = map)]
+    async fn list_settled_claims_metadata(
+        &self,
+        since: Timestamp,
+    ) -> RpcResult<Vec<Timestamped<SettledClaimData>>>;
+
+    /// Yields (recent) submitted claims metadata
+    ///
+    /// - Input: a [Timestamp] (`since`)
+    /// - Returns: a list containing metadata for the most recent submitted claims recorded since the given timestamp (limited at 64 entries).
+    #[method(name = "vsl_listSubmittedClaimsMetadata", param_kind = map)]
+    async fn list_submitted_claims_metadata(
+        &self,
+        since: Timestamp,
+    ) -> RpcResult<Vec<Timestamped<SubmittedClaimData>>>;
+
+
 
     /// Yields (recent) settled claims for a receiver.
     ///
@@ -116,6 +137,34 @@ pub trait ClaimRpc {
         address: Option<String>,
         since: Timestamp,
     ) -> RpcResult<Vec<Timestamped<Signed<SubmittedClaim>>>>;
+
+    /// Retrieves the claim data contained in the submitted claim with the given ID.
+    ///
+    /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+    /// - Returns: the contents of the `claim` field from the corresponding [SubmittedClaim].
+    ///
+    /// Will fail if:
+    ///
+    /// - no claim with given ID is not found among the submitted claims
+    #[method(name = "vsl_getClaimDataById", param_kind = map)]
+    async fn get_claim_data_by_id(
+        &self,
+        claim_id: String,
+    ) -> RpcResult<String>;
+
+    /// Retrieves the proof contained in the submitted claim with the given ID.
+    ///
+    /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+    /// - Returns: the contents of the `proof` field from the corresponding [SubmittedClaim].
+    ///
+    /// Will fail if:
+    ///
+    /// - no claim with given ID is not found among the submitted claims
+    #[method(name = "vsl_getProofById", param_kind = map)]
+    async fn get_proof_by_id(
+        &self,
+        claim_id: String,
+    ) -> RpcResult<String>;
 
     /// Retrieves a settled claim by its unique claim ID.
     ///

--- a/vsl-sdk/src/rpc_service.rs
+++ b/vsl-sdk/src/rpc_service.rs
@@ -333,6 +333,30 @@ pub trait ClaimRpc {
     #[method(name = "vsl_getHealth", param_kind = map)]
     async fn get_health(&self) -> RpcResult<String>;
 
+    /// [Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the settled claims metadata
+    ///
+    /// - yields: a stream of timestamped [SettledClaimData]s
+    #[subscription(
+        name = "vsl_subscribeToSettledClaimsMetadata",
+        unsubscribe = "vsl_unsubscribeFromSettledClaimsMetadata",
+        param_kind = map,
+        item = Timestamped<SettledClaimData>)]
+    async fn subscribe_to_settled_claims_metadata(
+        &self,
+    ) -> SubscriptionResult;
+
+    /// [Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the claim verification requests metadata
+    ///
+    /// - yields: a stream of timestamped [SubmittedClaimData]s
+    #[subscription(
+        name = "vsl_subscribeToSubmittedClaimsMetadata",
+        unsubscribe = "vsl_unsubscribeFromSubmittedMetadata",
+        param_kind = map,
+        item = Timestamped<SubmittedClaimData>)]
+    async fn subscribe_to_submitted_claims_metadata(
+        &self,
+    ) -> SubscriptionResult;
+
     /// [Subscription](https://geth.ethereum.org/docs/rpc/pubsub) to the settled claims for a receiver
     ///
     /// - Input: the (Ethereum-style) address of the account for which settled claims are tracked (optional)

--- a/vsl-sdk/src/rpc_wrapper.rs
+++ b/vsl-sdk/src/rpc_wrapper.rs
@@ -481,6 +481,22 @@ where
         get_settled_claim_by_id(&self.rpc_client, claim_id).await
     }
 
+    /// Retrieves a submitted claim by its unique claim ID.
+    ///
+    /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+    /// - Returns: the timestamped and signed [SubmittedClaim] claim corresponding to the given claim ID.
+    ///
+    /// Will fail if:
+    ///
+    /// - claim is not found among the submitted claims
+    pub async fn get_submitted_claim_by_id(
+        &self,
+        // the Keccak256 hash of the claim creator, creation nonce, and claim string.
+        claim_id: &B256,
+    ) -> RpcWrapperResult<Timestamped<Signed<SubmittedClaim>>> {
+        get_submitted_claim_by_id(&self.rpc_client, claim_id).await
+    }
+
     /// Retrieves the claim data contained in the submitted claim with the given ID.
     ///
     /// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
@@ -649,6 +665,25 @@ pub async fn get_proof_by_id<T: ClientT>(
 ) -> RpcWrapperResult<String> {
     let response = rpc_client
         .request("vsl_getProofById", rpc_params![claim_id.to_string()])
+        .await?;
+    Ok(response)
+}
+
+/// Retrieves a submitted claim by its unique claim ID.
+///
+/// - Input: a claim ID, which is the Keccak256 hash of the claim creator, creation nonce, and claim string.
+/// - Returns: the timestamped and signed [SubmittedClaim] claim corresponding to the given claim ID.
+///
+/// Will fail if:
+///
+/// - claim is not found among the submitted claims
+pub async fn get_submitted_claim_by_id<T: ClientT>(
+    rpc_client: &T,
+    // the Keccak256 hash of the claim creator, creation nonce, and claim string.
+    claim_id: &B256,
+) -> RpcWrapperResult<Timestamped<Signed<SubmittedClaim>>> {
+    let response = rpc_client
+        .request("vsl_getSubmittedClaimById", rpc_params![claim_id.to_string()])
         .await?;
     Ok(response)
 }


### PR DESCRIPTION
This PR adds the following endpoints:

- `vsl_listSettledClaimsMetadata`
  - response is a list of Timestamped<SettledClaimData> with the claim id being the `id` field in the `Timestamped` object.
- `vsl_listSubmittedClaimsMetadata`
- `vsl_getClaimDataById`
-  `vsl_getProofById`

As well as the following subscriptions:

- `vsl_subscribeToSettledClaimsMetadata`
- `vsl_subscribeToSubmittedClaimsMetadata`
- 