### PR TITLE
Add a Timestamp constructor

### DIFF
--- a/vsl-sdk/src/timestamp.rs
+++ b/vsl-sdk/src/timestamp.rs
@@ -42,6 +42,10 @@ impl Timestamp {
         }
     }
 
+    pub fn from_parts(seconds: u64, nanos: u32) -> Self {
+        Timestamp { seconds, nanos }
+    }
+
     pub fn seconds(&self) -> u64 {
         self.seconds
     }


### PR DESCRIPTION
Adds a function to make a timestamp from parts.
Construction wasn't intended to be restricted,
and it was already possibly to construct arbitrary timestamps with FromStr,
but there was no public constructor.